### PR TITLE
Stash integration (webhook and PR reporter)

### DIFF
--- a/master/buildbot/newsfragments/reporters_stash.feature
+++ b/master/buildbot/newsfragments/reporters_stash.feature
@@ -1,0 +1,1 @@
+Allow sending a comment to a pull request for Bibucket Server in :py:class:`~buildbot.reporters.stash.StashPRCommentPush`

--- a/master/buildbot/newsfragments/www_hooks_bitbucketserver.feature
+++ b/master/buildbot/newsfragments/www_hooks_bitbucketserver.feature
@@ -1,0 +1,1 @@
+Implement support for Bitbucket Server webhooks plugin in :py:class:`~buildbot.www.hooks.bitbucketserver.BitbucketServerEventHandler`

--- a/master/buildbot/reporters/stash.py
+++ b/master/buildbot/reporters/stash.py
@@ -35,6 +35,8 @@ STASH_SUCCESSFUL = 'SUCCESSFUL'
 STASH_FAILED = 'FAILED'
 STASH_STATUS_API_URL = '/rest/build-status/1.0/commits/{sha}'
 STASH_COMMENT_API_URL = '/rest/api/1.0{path}/comments'
+HTTP_PROCESSED = 204
+HTTP_CREATED = 201
 
 
 class StashStatusPush(http.HttpStatusPushBase):
@@ -86,7 +88,7 @@ class StashStatusPush(http.HttpStatusPushBase):
                 payload['name'] = yield props.render(self.statusName)
             response = yield self._http.post(
                 STASH_STATUS_API_URL.format(sha=sha), json=payload)
-            if response.code == 204:
+            if response.code == HTTP_PROCESSED:
                 if self.verbose:
                     log.info('Status "{status}" sent for {sha}.',
                              status=status, sha=sha)
@@ -130,7 +132,7 @@ class StashPRCommentPush(http.HttpStatusPushBase):
         response = yield self._http.post(
             STASH_COMMENT_API_URL.format(path=path),json=payload)
 
-        if response.code == 201:
+        if response.code == HTTP_CREATED:
             if self.verbose:
                 log.info('{comment} sent to {url}',
                          comment=comment_text, url=pr_url)

--- a/master/buildbot/reporters/stash.py
+++ b/master/buildbot/reporters/stash.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.moves.urllib.parse import urlparse
 
 from twisted.internet import defer
 
@@ -24,6 +25,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters import http
 from buildbot.util import httpclientservice
 from buildbot.util.logger import Logger
+from buildbot.util import unicode2bytes
 
 log = Logger()
 
@@ -31,6 +33,8 @@ log = Logger()
 STASH_INPROGRESS = 'INPROGRESS'
 STASH_SUCCESSFUL = 'SUCCESSFUL'
 STASH_FAILED = 'FAILED'
+STASH_STATUS_API_URL = '/rest/build-status/1.0/commits/{sha}'
+STASH_COMMENT_API_URL = '/rest/api/1.0{path}/comments'
 
 
 class StashStatusPush(http.HttpStatusPushBase):
@@ -73,8 +77,8 @@ class StashStatusPush(http.HttpStatusPushBase):
                 payload['description'] = yield props.render(description)
             if self.statusName:
                 payload['name'] = yield props.render(self.statusName)
-            response = yield self._http.post('/rest/build-status/1.0/commits/' + sha,
-                                             json=payload)
+            response = yield self._http.post(STASH_STATUS_API_URL
+                                                .format(sha=sha), json=payload)
             if response.code == 204:
                 if self.verbose:
                     log.info('Status "{status}" sent for {sha}.',
@@ -83,3 +87,47 @@ class StashStatusPush(http.HttpStatusPushBase):
                 content = yield response.content()
                 log.error("{code}: Unable to send Stash status: {content}",
                           code=response.code, content=content)
+
+
+class StashPRCommentPush(http.HttpStatusPushBase):
+    name = "StashPRCommentPush"
+
+    @defer.inlineCallbacks
+    def reconfigService(self, base_url, user, password, text=None,
+                        verbose=False, **kwargs):
+        yield http.HttpStatusPushBase.reconfigService(self, wantProperties=True,
+                                                      **kwargs)
+        self.text = text or Interpolate('Builder: %(prop:buildername)s '
+                                        'Status: %(prop:statustext)s')
+        self.verbose = verbose
+        self._http = yield httpclientservice.HTTPClientService.getService(
+            self.master, base_url, auth=(user, password),
+            debug=self.debug, verify=self.verify)
+
+    @defer.inlineCallbacks
+    def send(self, build):
+        if build['complete'] and build['properties'].has_key("pullrequesturl"):
+            yield self.sendPullRequestComment(build)
+
+    @defer.inlineCallbacks
+    def sendPullRequestComment(self, build):
+        props = Properties.fromDict(build['properties'])
+        pr_url = props.getProperty("pullrequesturl")
+        # we assume that the PR URL is well-formed as it comes from a PR event
+        path = urlparse(unicode2bytes(pr_url)).path
+        status = "SUCCESS" if build['results'] == SUCCESS else "FAILED"
+        props.setProperty('statustext', status, self.name)
+        props.setProperty('url', build['url'], self.name)
+        comment_text = yield props.render(self.text)
+        payload = {'text' : comment_text}
+        response = yield self._http.post(
+            STASH_COMMENT_API_URL.format(path=path),json=payload)
+
+        if response.code == 201:
+            if self.verbose:
+                log.info('{comment} sent to {url}',
+                         comment=comment_text, url=pr_url)
+        else:
+            content = yield response.content()
+            log.error("{code}: Unable to send a comment: {content}",
+                      code=response.code, content=content)

--- a/master/buildbot/reporters/stash.py
+++ b/master/buildbot/reporters/stash.py
@@ -84,8 +84,8 @@ class StashStatusPush(http.HttpStatusPushBase):
                 payload['description'] = yield props.render(description)
             if self.statusName:
                 payload['name'] = yield props.render(self.statusName)
-            response = yield self._http.post(STASH_STATUS_API_URL
-                                                .format(sha=sha), json=payload)
+            response = yield self._http.post(
+                STASH_STATUS_API_URL.format(sha=sha), json=payload)
             if response.code == 204:
                 if self.verbose:
                     log.info('Status "{status}" sent for {sha}.',

--- a/master/buildbot/test/unit/test_reporter_stash.py
+++ b/master/buildbot/test/unit/test_reporter_stash.py
@@ -22,9 +22,11 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
+from buildbot.process.properties import Interpolate
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.reporters.stash import StashStatusPush
+from buildbot.reporters.stash import StashPRCommentPush
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.logging import LoggingMixin
@@ -138,3 +140,93 @@ class TestStashStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin):
         self.setUpLogging()
         self.sp.buildStarted(("build", 20, "started"), build)
         self.assertLogged('404: Unable to send Stash status')
+
+
+class TestStashPRCommentPush(unittest.TestCase, ReporterTestMixin, LoggingMixin):
+
+    @defer.inlineCallbacks
+    def setupReporter(self, **kwargs):
+        # ignore config error if txrequests is not installed
+        self.patch(config, '_errors', Mock())
+        self.master = fakemaster.make_master(testcase=self,
+                                             wantData=True, wantDb=True, wantMq=True)
+
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self, 'serv', auth=('username', 'passwd'), debug=None,
+            verify=None)
+        self.sp = sp = StashPRCommentPush("serv", "username", "passwd", **kwargs)
+        yield sp.setServiceParent(self.master)
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def setupBuildResults(self, buildResults):
+        self.insertTestData([buildResults], buildResults)
+        self.master.db.builds.setBuildProperty(
+            20, "pullrequesturl",
+            "http://example.com/projects/PRO/repos/myrepo/pull-requests/20", "test")
+        build = yield self.master.data.get(("builds", 20))
+        defer.returnValue(build)
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        self.setupReporter()
+        build = yield self.setupBuildResults(SUCCESS)
+        self._http.expect(
+            "post",
+             u'/rest/api/1.0/projects/PRO/repos/myrepo/pull-requests/20/comments',
+            json={"text" : "Builder: Builder0 Status: SUCCESS"},
+            code=201)
+        build["complete"] = False
+        # this shouldn't send anything
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertEqual(len(self._http._expected), 1)
+        build["complete"] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        self._http.expect(
+            "post",
+            u'/rest/api/1.0/projects/PRO/repos/myrepo/pull-requests/20/comments',
+            json={"text" : "Builder: Builder0 Status: FAILED"},
+            code=201)
+        build["results"] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_setting_options(self):
+        self.setupReporter(text=Interpolate('url: %(prop:url)s status: %(prop:statustext)s'))
+        build = yield self.setupBuildResults(SUCCESS)
+        self._http.expect(
+            "post",
+             u'/rest/api/1.0/projects/PRO/repos/myrepo/pull-requests/20/comments',
+            json={'text': 'url: http://localhost:8080/#builders/79/builds/0 status: SUCCESS'},
+            code=201)
+        build["complete"] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertEqual(len(self._http._expected), 1)
+        build["complete"] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        self._http.expect(
+            "post",
+            u'/rest/api/1.0/projects/PRO/repos/myrepo/pull-requests/20/comments',
+            json={'text': 'url: http://localhost:8080/#builders/79/builds/0 status: FAILED'},
+            code=201)
+        build["results"] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_error(self):
+        self.setupReporter()
+        build = yield self.setupBuildResults(SUCCESS)
+        self._http.expect(
+            "post",
+            u'/rest/api/1.0/projects/PRO/repos/myrepo/pull-requests/20/comments',
+            json={"text" : "Builder: Builder0 Status: SUCCESS"},
+            code=404,
+            content_json=None)
+        self.setUpLogging()
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.assertLogged('404: Unable to send a comment: None')

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -661,6 +661,11 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
                          'http://localhost:7990/projects/'
                          'CI/repos/py-repo/pull-requests/21')
         self.assertEqual(change['revision'], None)
+        pr_url = change['properties'].get('pullrequesturl')
+        self.assertNotEqual(pr_url, None)
+        self.assertEqual(
+            pr_url,
+            "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21")
 
     @defer.inlineCallbacks
     def testHookWithChangeOnPullRequestCreated(self):

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -741,7 +741,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
                                          {'codebase' : 'super-codebase'}}
         yield self._checkCodebase('repo:push', 'super-codebase')
 
-
     @defer.inlineCallbacks
     def testHookWithCodebaseFunctionOnPushEvent(self):
         self.change_hook.dialects = {'bitbucketserver':

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -743,11 +743,10 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     @defer.inlineCallbacks
     def testHookWithCodebaseFunctionOnPushEvent(self):
-        self.change_hook.dialects = {'bitbucketserver':
-                                         {'codebase': lambda payload :
-                                            payload['repository']
-                                                   ['project']
-                                                   ['key']}}
+        self.change_hook.dialects = {
+            'bitbucketserver': {
+                'codebase':
+                    lambda payload : payload['repository']['project']['key']}}
         yield self._checkCodebase('repo:push', 'CI')
 
     @defer.inlineCallbacks
@@ -758,11 +757,10 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     @defer.inlineCallbacks
     def testHookWithCodebaseFunctionOnPullEvent(self):
-        self.change_hook.dialects = {'bitbucketserver':
-                                         {'codebase': lambda payload :
-                                            payload['repository']
-                                                   ['project']
-                                                   ['key']}}
+        self.change_hook.dialects = {
+            'bitbucketserver': {
+                'codebase':
+                    lambda payload : payload['repository']['project']['key']}}
         yield self._checkCodebase('pullrequest:updated', 'CI')
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -1,0 +1,798 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+# Copyright Mamba Team
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from StringIO import StringIO
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+import buildbot.www.change_hook as change_hook
+from buildbot.test.fake.web import FakeRequest
+from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.www.hooks.bitbucketserver import _HEADER_EVENT
+from buildbot.www.hooks.bitbucketserver import _HEADER_CT
+
+_CT_JSON = 'application/json'
+
+pushJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "CI",
+			"name": "Continuous Integration"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+				}
+			]
+		},
+		"public": false,
+		"ownerName": "CI",
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	},
+	"push": {
+		"changes": [
+			{
+				"created": false,
+				"closed": false,
+				"new": {
+					"type": "branch",
+					"name": "branch_1496411680",
+					"target": {
+						"type": "commit",
+						"hash": "793d4754230023d85532f9a38dba3290f959beb4"
+					}
+				},
+				"old": {
+					"type": "branch",
+					"name": "branch_1496411680",
+					"target": {
+						"type": "commit",
+						"hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba"
+					}
+				}
+			}
+		]
+	}
+}
+"""
+
+pullRequestCreatedJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"pullrequest": {
+		"id": "21",
+		"title": "dot 1496311906",
+		"link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+		"authorLogin": "John Smith",
+		"fromRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+				"name": "branch_1496411680"
+			}
+		},
+		"toRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"name": "master"
+			}
+		}
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "CI",
+			"name": "Continuous Integration"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+				}
+			]
+		},
+		"public": false,
+		"ownerName": "CI",
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	}
+}
+"""
+
+pullRequestUpdatedJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"pullrequest": {
+		"id": "21",
+		"title": "dot 1496311906",
+		"link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+		"authorLogin": "Buildbot",
+		"fromRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "793d4754230023d85532f9a38dba3290f959beb4",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "793d4754230023d85532f9a38dba3290f959beb4",
+				"name": "branch_1496411680"
+			}
+		},
+		"toRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"name": "master"
+			}
+		}
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "CI",
+			"name": "Continuous Integration"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+				}
+			]
+		},
+		"public": false,
+		"ownerName": "CI",
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	}
+}
+"""
+
+pullRequestRejectedJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"pullrequest": {
+		"id": "21",
+		"title": "dot 1496311906",
+		"link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+		"authorLogin": "Buildbot",
+		"fromRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "793d4754230023d85532f9a38dba3290f959beb4",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "793d4754230023d85532f9a38dba3290f959beb4",
+				"name": "branch_1496411680"
+			}
+		},
+		"toRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"name": "master"
+			}
+		}
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "CI",
+			"name": "Continuous Integration"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+				}
+			]
+		},
+		"public": false,
+		"ownerName": "CI",
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	}
+}
+"""
+
+pullRequestFulfilledJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"pullrequest": {
+		"id": "21",
+		"title": "Branch 1496411680",
+		"link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+		"authorLogin": "Buildbot",
+		"fromRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "793d4754230023d85532f9a38dba3290f959beb4",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "793d4754230023d85532f9a38dba3290f959beb4",
+				"name": "branch_1496411680"
+			}
+		},
+		"toRef": {
+			"repository": {
+				"scmId": "git",
+				"project": {
+					"key": "CI",
+					"name": "Continuous Integration"
+				},
+				"slug": "py-repo",
+				"links": {
+					"self": [
+						{
+							"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+						}
+					]
+				},
+				"public": false,
+				"ownerName": "CI",
+				"owner": {
+					"username": "CI",
+					"displayName": "CI"
+				},
+				"fullName": "CI/py-repo"
+			},
+			"commit": {
+				"message": null,
+				"date": null,
+				"hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"authorTimestamp": 0
+			},
+			"branch": {
+				"rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+				"name": "master"
+			}
+		}
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "CI",
+			"name": "Continuous Integration"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+				}
+			]
+		},
+		"public": false,
+		"ownerName": "CI",
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	}
+}
+"""
+
+deleteTagJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "CI",
+			"name": "Continuous Integration"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/CI/repos/py-repo/browse"
+				}
+			]
+		},
+		"ownerName": "BUIL",
+		"public": false,
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	},
+	"push": {
+		"changes": [
+			{
+				"created": false,
+				"closed": true,
+				"old": {
+					"type": "tag",
+					"name": "1.0.0",
+					"target": {
+						"type": "commit",
+						"hash": "8eecf59b93ba4fd8d6bb578f6632fc3f5994d331"
+					}
+				},
+				"new": null
+			}
+		]
+	}
+}
+"""
+
+deleteBranchJsonPayload = """
+{
+	"actor": {
+		"username": "John",
+		"displayName": "John Smith"
+	},
+	"repository": {
+		"scmId": "git",
+		"project": {
+			"key": "BUIL",
+			"name": "buildbot"
+		},
+		"slug": "py-repo",
+		"links": {
+			"self": [
+				{
+					"href": "http://localhost:7990/projects/BUIL/repos/py-repo/browse"
+				}
+			]
+		},
+		"ownerName": "CI",
+		"public": false,
+		"owner": {
+			"username": "CI",
+			"displayName": "CI"
+		},
+		"fullName": "CI/py-repo"
+	},
+	"push": {
+		"changes": [
+			{
+				"created": false,
+				"closed": true,
+				"old": {
+					"type": "branch",
+					"name": "branch_1496758965",
+					"target": {
+						"type": "commit",
+						"hash": "8eecf59b93ba4fd8d6bb578f6632fc3f5994d331"
+					}
+				},
+				"new": null
+			}
+		]
+	}
+}
+"""
+
+def _prepare_request(payload, headers=None, change_dict=None):
+    headers = headers or {}
+    request = FakeRequest(change_dict)
+    request.uri = "/change_hook/bitbucketserver"
+    request.method = "POST"
+    request.content = StringIO(payload)
+    request.received_headers[_HEADER_CT] = _CT_JSON
+    request.received_headers.update(headers)
+    return request
+
+
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+
+    """Unit tests for Bitbucket Server Change Hook
+    """
+
+    def setUp(self):
+        self.change_hook = change_hook.ChangeHookResource(
+            dialects={'bitbucketserver': {}}, master=fakeMasterForHooks())
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPushEvent(self):
+
+        request = _prepare_request(
+                    pushJsonPayload,
+                    headers={_HEADER_EVENT : 'repo:push'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(
+            change['repository'],
+            'http://localhost:7990/projects/CI/repos/py-repo/')
+        self.assertEqual(change['author'], 'John Smith <John>')
+        self.assertEqual(change['project'], 'Continuous Integration')
+        self.assertEqual(change['revision'],
+                         '793d4754230023d85532f9a38dba3290f959beb4')
+        self.assertEqual(
+            change['comments'], 'Bitbucket Server commit '
+                                '793d4754230023d85532f9a38dba3290f959beb4')
+        self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
+        self.assertEqual(
+            change['revlink'],
+            'http://localhost:7990/projects/CI/repos/py-repo/commits/'
+            '793d4754230023d85532f9a38dba3290f959beb4')
+        self.assertEqual(change['category'], 'push')
+
+    def _checkPullRequest(self, change):
+        self.assertEqual(
+            change['repository'],
+            'http://localhost:7990/projects/CI/repos/py-repo/')
+        self.assertEqual(change['author'], 'John Smith <John>')
+        self.assertEqual(change['project'], 'Continuous Integration')
+        self.assertEqual(change['comments'],
+                         'Bitbucket Server Pull Request #21')
+        self.assertEqual(change['revlink'],
+                         'http://localhost:7990/projects/'
+                         'CI/repos/py-repo/pull-requests/21')
+        self.assertEqual(change['revision'], None)
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestCreated(self):
+        request = _prepare_request(
+                    pullRequestCreatedJsonPayload,
+                    headers={_HEADER_EVENT : 'pullrequest:created'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
+        self.assertEqual(change['category'], 'pull-created')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestUpdated(self):
+        request = _prepare_request(
+                    pullRequestUpdatedJsonPayload,
+                    headers={_HEADER_EVENT : 'pullrequest:updated'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
+        self.assertEqual(change['category'], 'pull-updated')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestRejected(self):
+        request = _prepare_request(
+                    pullRequestRejectedJsonPayload,
+                    headers={_HEADER_EVENT : 'pullrequest:rejected'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
+        self.assertEqual(change['category'], 'pull-rejected')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestFulfilled(self):
+        request = _prepare_request(
+                    pullRequestFulfilledJsonPayload,
+                    headers={_HEADER_EVENT : 'pullrequest:fulfilled'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/heads/master')
+        self.assertEqual(change['category'], 'pull-fulfilled')
+
+    @defer.inlineCallbacks
+    def _checkCodebase(self, event_type, expected_codebase):
+        payloads = {'repo:push' : pushJsonPayload,
+                    'pullrequest:updated' : pullRequestUpdatedJsonPayload}
+        request = _prepare_request(
+            payloads[event_type],
+            headers={_HEADER_EVENT: event_type})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(change['codebase'], expected_codebase)
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseValueOnPushEvent(self):
+        self.change_hook.dialects = {'bitbucketserver' :
+                                         {'codebase' : 'super-codebase'}}
+        yield self._checkCodebase('repo:push', 'super-codebase')
+
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseFunctionOnPushEvent(self):
+        self.change_hook.dialects = {'bitbucketserver':
+                                         {'codebase': lambda payload :
+                                            payload['repository']
+                                                   ['project']
+                                                   ['key']}}
+        yield self._checkCodebase('repo:push', 'CI')
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseValueOnPullEvent(self):
+        self.change_hook.dialects = {'bitbucketserver' :
+                                         {'codebase' : 'super-codebase'}}
+        yield self._checkCodebase('pullrequest:updated', 'super-codebase')
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseFunctionOnPullEvent(self):
+        self.change_hook.dialects = {'bitbucketserver':
+                                         {'codebase': lambda payload :
+                                            payload['repository']
+                                                   ['project']
+                                                   ['key']}}
+        yield self._checkCodebase('pullrequest:updated', 'CI')
+
+    @defer.inlineCallbacks
+    def testHookWithUnhandledEvent(self):
+        request = _prepare_request(
+                    pushJsonPayload,
+                    headers={_HEADER_EVENT : 'invented:event'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(request.written, "Unknown event: invented_event")
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnDeleteTag(self):
+        request = _prepare_request(
+                    deleteTagJsonPayload,
+                    headers={_HEADER_EVENT : 'repo:push'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnDeleteBranch(self):
+        request = _prepare_request(
+                    deleteBranchJsonPayload,
+                    headers={_HEADER_EVENT : 'repo:push'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+
+    @defer.inlineCallbacks
+    def testHookWithInvalidContentType(self):
+        request = _prepare_request(
+                    pushJsonPayload,
+                    headers={_HEADER_EVENT : 'repo:push'})
+        request.received_headers[_HEADER_CT] = 'invalid/content'
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(request.written,
+                         "Unknown content type: invalid/content")

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -36,7 +36,7 @@ class BitbucketServerEventHandler(object):
         log.msg("Processing event {header}: {event}"
                 .format(header=_HEADER_EVENT, event=event_type))
         event_type = event_type.replace(":", "_")
-        handler = getattr(self, 'handle_%s' % event_type, None)
+        handler = getattr(self, 'handle_{}'.format(event_type), None)
 
         if handler is None:
             raise ValueError('Unknown event: {}'.format(event_type))
@@ -144,12 +144,6 @@ class BitbucketServerEventHandler(object):
 
 
 def getChanges(request, options=None):
-    """
-    Process the Bitbucket Server webhook event.
-
-    :param twisted.web.server.Request request: the http request object
-
-    """
     if not isinstance(options, dict):
         options = {}
 

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -137,7 +137,8 @@ class BitbucketServerEventHandler(object):
             'category': category,
             'author': '{} <{}>'.format(payload['actor']['displayName'],
                                        payload['actor']['username']),
-            'comments': 'Bitbucket Server Pull Request #{}'.format(pr_number)
+            'comments': 'Bitbucket Server Pull Request #{}'.format(pr_number),
+            'properties' : {'pullrequesturl' : payload['pullrequest']['link']}
         }
 
         if callable(self._codebase):

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -90,8 +90,6 @@ class BitbucketServerEventHandler(object):
 
             changes.append(change)
 
-        log.msg('Received {} changes from Bitbucket Server'
-                .format(len(changes)))
         return (changes, payload['repository']['scmId'])
 
     def handle_pullrequest_created(self, payload):
@@ -145,8 +143,6 @@ class BitbucketServerEventHandler(object):
 
         changes.append(change)
 
-        log.msg("Received a change from Bitbucket Server PR #{}"
-                .format(pr_number))
         return changes, payload['repository']['scmId']
 
 

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -13,8 +13,6 @@
 #
 # Copyright Buildbot Team Members
 # Copyright Mamba Team
-import logging
-from dateutil.parser import parse as dateparse
 
 from twisted.python import log
 

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -72,18 +72,17 @@ class BitbucketServerEventHandler(object):
                 continue
 
             change = {
-                'author': "%s <%s>" %
-                    (payload['actor']['displayName'],
-                     payload['actor']['username']),
-                'comments': 'Bitbucket Server commit %s' %
-                    payload_change['new']['target']['hash'],
                 'revision': payload_change['new']['target']['hash'],
-                'branch': 'refs/heads/%s' % payload_change['new']['name'],
-                'revlink': '%scommits/%s' %
-                    (repo_url, payload_change['new']['target']['hash']),
+                'revlink': '{}commits/{}'.format(
+                    repo_url, payload_change['new']['target']['hash']),
                 'repository': repo_url,
-                'category' : 'push',
-                'project': project
+                'author': '{} <{}>'.format(payload['actor']['displayName'],
+                                           payload['actor']['username']),
+                'comments': 'Bitbucket Server commit {}'.format(
+                    payload_change['new']['target']['hash']),
+                'branch': GIT_HEAD_REF.format(payload_change['new']['name']),
+                'project' : project,
+                'category' : 'push'
             }
 
             if callable(self._codebase):
@@ -132,12 +131,12 @@ class BitbucketServerEventHandler(object):
             'revision': None,
             'revlink': payload['pullrequest']['link'],
             'repository': repo_url,
-            'branch' : refname,
-            'project': payload['repository']['project']['name'],
-            'category': category,
             'author': '{} <{}>'.format(payload['actor']['displayName'],
                                        payload['actor']['username']),
             'comments': 'Bitbucket Server Pull Request #{}'.format(pr_number),
+            'branch' : refname,
+            'project': payload['repository']['project']['name'],
+            'category': category,
             'properties' : {'pullrequesturl' : payload['pullrequest']['link']}
         }
 

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -1,0 +1,167 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+# Copyright Mamba Team
+import logging
+from dateutil.parser import parse as dateparse
+
+from twisted.python import log
+
+import json
+
+GIT_MERGE_REF = "refs/pull-requests/{}/merge"
+GIT_HEAD_REF = "refs/heads/{}"
+
+_HEADER_CT = 'Content-Type'
+_HEADER_EVENT = 'X-Event-Key'
+
+class BitbucketServerEventHandler(object):
+
+    def __init__(self, codebase=None, options={}):
+        self._codebase = codebase
+        self.options = options
+
+    def process(self, request):
+        payload = self._get_payload(request)
+        event_type = request.getHeader(_HEADER_EVENT)
+        log.msg("Processing event {header}: {event}"
+                .format(header=_HEADER_EVENT, event=event_type))
+        event_type = event_type.replace(":", "_")
+        handler = getattr(self, 'handle_%s' % event_type, None)
+
+        if handler is None:
+            raise ValueError('Unknown event: {}'.format(event_type))
+
+        return handler(payload)
+
+    def _get_payload(self, request):
+        content = request.content.read()
+        content_type = request.getHeader(_HEADER_CT)
+        if content_type.startswith('application/json'):
+            payload = json.loads(content)
+        elif content_type.startswith('application/x-www-form-urlencoded'):
+            payload = json.loads(request.args['payload'][0])
+        else:
+            raise ValueError('Unknown content type: {}'
+                             .format(content_type))
+
+        log.msg("Payload: {}".format(payload))
+
+        return payload
+
+    def handle_repo_push(self, payload):
+        changes = []
+        project = payload['repository']['project']['name']
+        repo_url = payload['repository']['links']['self'][0]['href']
+        repo_url = repo_url.rstrip('browse')
+
+        for payload_change in payload['push']['changes']:
+            if not payload_change['new']:
+                # skip change if deleting a tag or a branch
+                continue
+
+            change = {
+                'author': "%s <%s>" %
+                    (payload['actor']['displayName'],
+                     payload['actor']['username']),
+                'comments': 'Bitbucket Server commit %s' %
+                    payload_change['new']['target']['hash'],
+                'revision': payload_change['new']['target']['hash'],
+                'branch': 'refs/heads/%s' % payload_change['new']['name'],
+                'revlink': '%scommits/%s' %
+                    (repo_url, payload_change['new']['target']['hash']),
+                'repository': repo_url,
+                'category' : 'push',
+                'project': project
+            }
+
+            if callable(self._codebase):
+                change['codebase'] = self._codebase(payload)
+            elif self._codebase is not None:
+                change['codebase'] = self._codebase
+
+            changes.append(change)
+
+        log.msg('Received {} changes from Bitbucket Server'
+                .format(len(changes)))
+        return (changes, payload['repository']['scmId'])
+
+    def handle_pullrequest_created(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_MERGE_REF.format(int(payload['pullrequest']['id'])),
+            "pull-created")
+
+    def handle_pullrequest_updated(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_MERGE_REF.format(int(payload['pullrequest']['id'])),
+            "pull-updated")
+
+    def handle_pullrequest_fulfilled(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_HEAD_REF.format(
+                payload['pullrequest']['toRef']['branch']['name']),
+            "pull-fulfilled")
+
+    def handle_pullrequest_rejected(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_HEAD_REF.format(
+                payload['pullrequest']['fromRef']['branch']['name']),
+            "pull-rejected")
+
+    def handle_pullrequest(self, payload, refname, category):
+        changes = []
+        pr_number = int(payload['pullrequest']['id'])
+        repo_url = payload['repository']['links']['self'][0]['href']
+        repo_url = repo_url.rstrip('browse')
+        change = {
+            'revision': None,
+            'revlink': payload['pullrequest']['link'],
+            'repository': repo_url,
+            'branch' : refname,
+            'project': payload['repository']['project']['name'],
+            'category': category,
+            'author': '{} <{}>'.format(payload['actor']['displayName'],
+                                       payload['actor']['username']),
+            'comments': 'Bitbucket Server Pull Request #{}'.format(pr_number)
+        }
+
+        if callable(self._codebase):
+            change['codebase'] = self._codebase(payload)
+        elif self._codebase is not None:
+            change['codebase'] = self._codebase
+
+        changes.append(change)
+
+        log.msg("Received a change from Bitbucket Server PR #{}"
+                .format(pr_number))
+        return changes, payload['repository']['scmId']
+
+
+def getChanges(request, options=None):
+    """
+    Process the Bitbucket Server webhook event.
+
+    :param twisted.web.server.Request request: the http request object
+
+    """
+    if not isinstance(options, dict):
+        options = {}
+
+    handler = BitbucketServerEventHandler(options.get('codebase', None),
+            options)
+    return handler.process(request)

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -119,7 +119,6 @@ class BitbucketServerEventHandler(object):
             "pull-rejected")
 
     def handle_pullrequest(self, payload, refname, category):
-        changes = []
         pr_number = int(payload['pullrequest']['id'])
         repo_url = payload['repository']['links']['self'][0]['href']
         repo_url = repo_url.rstrip('browse')
@@ -141,9 +140,7 @@ class BitbucketServerEventHandler(object):
         elif self._codebase is not None:
             change['codebase'] = self._codebase
 
-        changes.append(change)
-
-        return changes, payload['repository']['scmId']
+        return [change], payload['repository']['scmId']
 
 
 def getChanges(request, options=None):

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -1012,6 +1012,48 @@ As a result, we recommend you use https in your base_url rather than http.
     :param boolean verify: disable ssl verification for the case you use temporary self signed certificates
     :param boolean debug: logs every requests and their response
 
+.. bb:reporter:: StashPRCommentPush
+
+StashPRCommentPush
+~~~~~~~~~~~~~~~~~~
+
+.. @cindex StashPRCommentPush
+.. py:class:: buildbot.reporters.stash.StashPRCommentPush
+
+::
+
+    from buildbot.plugins import reporters
+
+    ss = reporters.StashPRCommentPush('https://bitbucket-server.example.com:8080/',
+                                   'bitbucket_server__username',
+                                   'secret_password')
+    c['services'].append(ss)
+
+
+:class:`StashPRCommentPush`  publishes a comment on a PR using `Bitbucket Server (former Stash) REST API <https://developer.atlassian.com/static/rest/bitbucket-server/5.0.1/bitbucket-rest.html#idm45993793481168>`_.
+
+
+.. py:class:: StashPRCommentPush(base_url, user, password, text=None, verbose=False, builders=None)
+
+    :param string base_url: The base url of the Bitbucket server host
+    :param string user: The Bitbucket server user to post as.
+    :param string password: The Bitbucket server user's password.
+    :param renderable string text: Used to render the comment text.
+        A static string can be passed or :class:`Interpolate` for dynamic substitution (default: `Interpolate('Builder: %(prop:buildername)s Status: %(prop:statustext)s')`).
+
+        Besides the build properties, you have the following available:
+
+        :url: link to the build page
+        :statustext: ``SUCCESS`` or ``FAILED`` according to the build status
+
+    :param boolean verbose: If True, logs a message for each successful status push.
+    :param list builders: Only send update for specified builders.
+    :param boolean verify: disable ssl verification for the case you use temporary self signed certificates
+    :param boolean debug: logs every requests and their response
+
+.. Note::
+    This reporter depends on the Bitbucket server hook to get the pull request url.
+
 .. bb:reporter:: BitbucketStatusPush
 
 BitbucketStatusPush

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -197,6 +197,32 @@ Then, create a BitBucket service hook (see https://confluence.atlassian.com/disp
 
 Note that as before, not using ``change_hook_auth`` can expose you to security risks.
 
+Bitbucket Server hook
++++++++++++++++++++++
+
+.. code-block:: python
+
+    c['www'] = dict(
+        ...,
+        change_hook_dialects={'bitbucketserver': {}},
+    )
+
+When this is setup you should add a webhook pointing to ``/change_hook/bitbucketserver`` relative to the root of the web status.
+
+According to the type of the event, the change category is set to ``push``, ``pull-created``, ``pull-rejected``, ``pull-updated`` or ``pull-fulfilled``.
+
+The Bitbucket Server hook may have the following optional parameters:
+
+``codebase`` (default `None`)
+    The codebase value to include with changes or a callable object that will be passed the payload in order to get it.
+
+.. Warning::
+    The incoming HTTP requests for this hook are not authenticated by default.
+    Anyone who can access the web server can "fake" a request from Bitbucket Server, potentially causing the buildmaster to run arbitrary code
+
+.. Note::
+    This hook is based on the bitbucket-webhooks plugin which is not included by default in Bitbucket Server
+
 Poller hook
 +++++++++++
 

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -221,7 +221,8 @@ The Bitbucket Server hook may have the following optional parameters:
     Anyone who can access the web server can "fake" a request from Bitbucket Server, potentially causing the buildmaster to run arbitrary code
 
 .. Note::
-    This hook is based on the bitbucket-webhooks plugin which is not included by default in Bitbucket Server
+    This hook requires the bitbucket-webhooks plugin (see https://marketplace.atlassian.com/plugins/nl.topicus.bitbucket.bitbucket-webhooks/server/overview).
+
 
 Poller hook
 +++++++++++


### PR DESCRIPTION
# Main Features
- Support Bitbucket server webhook events 
- Send customized comments to a pull request in Bitbucket server

## Notes
- The last [pull request](https://github.com/dls-controls/buildbot/pull/1) was closed in order to avoid confusion

## Contributor Checklist:
* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation
